### PR TITLE
bugfix: luajit does not understand "\ ", so we need to unescape it

### DIFF
--- a/bin/irep-generate
+++ b/bin/irep-generate
@@ -605,6 +605,10 @@ local function _wkt_to_loadable_lua(header)
    os.remove(outfile_name)
    os.remove(tmp_header)
 
+   -- lua is ok with it, but luajit does not like "\ ". Convert the
+   -- escaped spaces back to be compatible with both.
+   text = text:gsub("\\ ", " ")
+
    return text
 end
 


### PR DESCRIPTION
To preserve whitespace in multi-line Doc comments, we escape newlines and spaces. Lua is ok with "\n" and "\ ", but technically "\ " is not part of Lua, and Luajit complains about it.

- [x] `gsub` the "\ " back to " " before loading lua generated from WKTs