### PR TITLE
Remove requirement for C code to use -DIREP_LANG_C

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -14,7 +14,7 @@ hand:
 
 .. code-block:: console
 
-   gcc -E -DIREP_LANG_C       wkt_material.h | more
+   gcc -E wkt_material.h | more
    gcc -E -DIREP_LANG_FORTRAN wkt_material.h | more
    gcc -E -DIREP_LANG_LUA     wkt_material.h | more
    gcc -E -DIREP_GENERATE     wkt_material.h | more
@@ -23,6 +23,12 @@ hand:
 In other words, the ``wkt_*`` files produce output that can be read from
 C/C++, Fortran, or RST documentation. The output is similar in meaning,
 although not necessarily identical, in each language.
+
+By default, running a ``wkt`` header through the C preprocessor will generate C
+output. This allows them to be included without any special handling in C and
+C++ code. IREP's tooling (specifically, the ``irep-generate script`` uses the
+``IREP_LANG_*`` macros to generate code in other languages from ``wkt`` headers
+writtein in C.
 
 The Intermediate Representation (IR) is a tool for constructing a set of
 C/C++ and Fortran data structures, and a tool for reading Lua tables into

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ well; they invoke the C and Fortran compilers with a standard set of
 arguments for IREP programs:
 
 ```makefile
-COMPILE.c = $(CC) $(CFLAGS) $(CPPFLAGS) -DIREP_LANG_C
+COMPILE.c = $(CC) $(CFLAGS) $(CPPFLAGS)
 COMPILE.f = $(FC) $(FFLAGS) $(CPPFLAGS) -DIREP_LANG_FORTRAN
 ```
 
@@ -129,7 +129,6 @@ Program creation is somewhat simpler than with `gmake`:
 
 ```cmake
 add_executable(cxx_prog cxx_main.cpp)
-target_compile_definitions(cxx_prog PUBLIC -DIREP_LANG_C)
 target_link_libraries(
   cxx_prog
   prog-wkt
@@ -140,13 +139,10 @@ target_link_libraries(
 )
 ```
 
-Aside from adding `cxx_prog` as an executable, which is straightforward,
-this adds `-DIREP_LANG_C` as a definition for the exeuctable, and it adds
-IREP and lua libraries to the exe as well. `-DIREP_LANG_C` is necessary
-for IREP `wkt_*.h` files to be included in C programs -- it causes the
-preprocessor to translate them to proper `extern struct` declarations. We
-didn't have to do this in `gmake` because it was implicit in the C build
-rule, but CMake is more explicit than `gmake` in this regard.
+Aside from adding `cxx_prog` as an executable, which is straightforward, this
+also adds IREP and lua libraries to the exe. We didn't have to do this in
+`gmake` because it was implicit in the C build rule, but CMake is more explicit
+than `gmake` in this regard.
 
 The libraries linked with `cxx_prog` are essentially the same as those
 from `gmake`. However, `CMake` has no portable

--- a/examples/cxx-cmake/CMakeLists.txt
+++ b/examples/cxx-cmake/CMakeLists.txt
@@ -15,7 +15,6 @@ add_wkt_library(prog-wkt wkt_table1.h wkt_table4.h)
 add_wkt_index_library(prog-wkt-index wkt_table1.h wkt_table4.h)
 
 add_executable(cxx_prog cxx_main.cpp)
-target_compile_definitions(cxx_prog PUBLIC -DIREP_LANG_C)
 target_link_libraries(
   cxx_prog
   prog-wkt

--- a/ir_macros.h
+++ b/ir_macros.h
@@ -56,44 +56,6 @@
 #define Vstructure(T,ID,FB,CB) type(T) :: ID(FB)
 
 // ==================================================================
-// ===========================  C SECTION  ==========================
-// ==================================================================
-#elif defined(IREP_LANG_C)
-#define Doc(a)
-
-#define IR_STR(s) s
-
-#define ir_wkt(T,ID) extern T ID;
-#define Vir_wkt(T,ID,FB,CB) extern T ID[CB];
-
-#define Beg_struct(T) typedef struct T {
-#define End_struct(T) } T;
-
-#if defined(__cplusplus)
-#define BOOLEAN bool
-#else
-#define BOOLEAN _Bool
-#endif
-
-// Scalar double, integer, logical, string.
-#define ir_dbl(ID,DV) double ID;
-#define ir_int(ID,DV) int ID;
-#define ir_log(ID,DV) BOOLEAN ID;
-#define ir_str(ID,LEN,DV) char ID[LEN];
-#define ir_reference(ID) int ID;
-#define ir_ptr(ID) void *ID;
-
-// Vector double, integer, logical, string.
-#define Vir_dbl(ID,NELEM,DV) double ID[NELEM];
-#define Vir_int(ID,NELEM,DV) int ID[NELEM];
-#define Vir_log(ID,NELEM,DV) BOOLEAN ID[NELEM];
-#define Vir_str(ID,LEN,NELEM) char ID[NELEM][LEN];
-
-#define Structure(T,ID) T ID;
-#define Callback(ID,NP,NR) Structure(lua_cb_data, ID)
-#define Vstructure(T,ID,FB,CB) T ID[CB];
-
-// ==================================================================
 // ===========================  LUA SECTION  ========================
 // ==================================================================
 #elif defined(IREP_LANG_LUA)
@@ -154,10 +116,46 @@
 #define Vstructure(T,ID,FB,CB) T_tbl ID T FB
 
 // ==================================================================
-// ===========================  ERROR ===============================
+// ===========================  C SECTION  ==========================
 // ==================================================================
+#else  // no IREP_LANG_C required
+// Earlier versions of IREP required IREP_LANG_C to be defined, but
+// now the default is to generate C. This allows IREP headers to be
+// included without any special defines.
+
+#define Doc(a)
+
+#define IR_STR(s) s
+
+#define ir_wkt(T,ID) extern T ID;
+#define Vir_wkt(T,ID,FB,CB) extern T ID[CB];
+
+#define Beg_struct(T) typedef struct T {
+#define End_struct(T) } T;
+
+#if defined(__cplusplus)
+#define BOOLEAN bool
 #else
-#error No recognized language is defined.
+#define BOOLEAN _Bool
 #endif
 
-#endif
+// Scalar double, integer, logical, string.
+#define ir_dbl(ID,DV) double ID;
+#define ir_int(ID,DV) int ID;
+#define ir_log(ID,DV) BOOLEAN ID;
+#define ir_str(ID,LEN,DV) char ID[LEN];
+#define ir_reference(ID) int ID;
+#define ir_ptr(ID) void *ID;
+
+// Vector double, integer, logical, string.
+#define Vir_dbl(ID,NELEM,DV) double ID[NELEM];
+#define Vir_int(ID,NELEM,DV) int ID[NELEM];
+#define Vir_log(ID,NELEM,DV) BOOLEAN ID[NELEM];
+#define Vir_str(ID,LEN,NELEM) char ID[NELEM][LEN];
+
+#define Structure(T,ID) T ID;
+#define Callback(ID,NP,NR) Structure(lua_cb_data, ID)
+#define Vstructure(T,ID,FB,CB) T ID[CB];
+
+#endif  // defined IREP_LANG_*
+#endif  // ir_macros_h

--- a/share/irep/irep-config.cmake
+++ b/share/irep/irep-config.cmake
@@ -126,8 +126,6 @@ function(add_wkt_index_library name)
 
   # name of single C source file for index library
   set(WKT_INDEX_C "${name}.c")
-  set_source_files_properties(
-    "${WKT_INDEX_C}" PROPERTIES COMPILE_FLAGS -DIREP_LANG_C)
 
   # ensure that CPPFLAGS is set to include lib target properties
   set(incl "$<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>")

--- a/wkt.mk
+++ b/wkt.mk
@@ -69,7 +69,7 @@ irep_generate = $(irep_dir)/bin/irep-generate
 
 # Rules for compiling C and Forran files -- note that the appropriate
 # IREP -D flag must be set for files that include IREP headers.
-COMPILE.c = $(CC) $(CFLAGS) $(CPPFLAGS) -DIREP_LANG_C
+COMPILE.c = $(CC) $(CFLAGS) $(CPPFLAGS)
 COMPILE.f = $(FC) $(FFLAGS) $(CPPFLAGS) -DIREP_LANG_FORTRAN
 %.o: %.c       ; $(COMPILE.c) -c $<
 %.o %.mod: %.f ; $(COMPILE.f) -c $<


### PR DESCRIPTION
IREP WKT headers have traditionally required some `IREP_LANG_*` macro to be defined in order for them to pass through the C preprocessor without error. But if you look at the use cases, `IREP_LANG_C` shouldn't really be needed:

1. `IREP_LANG_FORTRAN`: used by `irep-generate` to generate nearly-complete Fortran code from a WKT header. `irep-generate` finishes the translation and outputs the completed Fortran module.

2. `IREP_LANG_LUA`: used by `irep-generate` to generate sort-of-complete Lua code from a WKT header. `irep-generate` finishes the translation and outputs the completed Lua file.

3. `IREP_LANG_GENERATE`: used by `irep-generate` to generate easy-to-parse symbosl that are then used by `irep-generate` to create table indices.

4. `IREP_LANG_C`: has to be defined when compiling any C or C++ code that includes a WKT header. Causes WKT headers to be translated to valid C.

The first three cases are used by tooling, not by client code. It makes sense that the tools might have to fiddle with defines to get the right output. But `IREP_LANG_C` is used by client code, and there isn't a reason you'd include a WKT header in C code unless you wanted IREP to generate C.

`wkt.mk` and `irep-config.cmake` handle defining this macro when building WKT libraries and indices, but codes that include the IREP headers have to do extra work, and this can be a stumbling block for new IREP users.

This PR removes the extra step for C code. `IREP_LANG_C` is no longer required, and IREP headers included with no `IREP_LANG_*` definition are assumed to be C.

- [x] Make `IREP_LANG_C` the default in `ir_macros.h`.
- [x] Get rid of error message when no `IREP_LANG_*` is defined.
- [x] Remove `IREP_LANG_C` from docs and examples.