### PR TITLE
bugfix: os.execute return value is different in lua >= 5.2

### DIFF
--- a/bin/irep-generate
+++ b/bin/irep-generate
@@ -208,7 +208,11 @@ end
 function execute_command(command)
    local tmpfile = os.tmpname() .. ".out"
    local exit = os.execute(command .. ' > ' .. tmpfile)
-   if exit ~= 0 then
+   local failed = (
+      (_ENV and exit == nil) or  -- lua >= 5.2
+      (not _ENV and exit ~= 0)   -- lua <  5.2
+   )
+   if failed then
       print("Command failed: '" .. command .. "'")
       os.exit(1)
    end


### PR DESCRIPTION
`os.execute()` returns `0` on success and the error code on failure in older Lua versions.

In newer (5.2 or higher) Lua versions, it returns `true` on success and `nil` on failure.

- [x] Update code for `execute_command()` to handle this.