### PR TITLE
fix namespaced include

### DIFF
--- a/ir_start.h
+++ b/ir_start.h
@@ -13,9 +13,9 @@ use, intrinsic :: iso_c_binding
 use :: ir_std
 
 #else
+#include "ir_std.h"
 #if defined(__cplusplus)
 namespace irep {
 extern "C" {
 #endif
-#include "ir_std.h"
 #endif


### PR DESCRIPTION
`ir_start.h` `#include`s `ir_std.h` in `namespace irep` with c++ compilers and if the first irep include is a `wkt_*.h` `lua_cb_data` will also be in `namespace irep`, which is unintended; fix this by moving the `#include "ir_std.h"`