### PR TITLE
Feature/askinner/hdiv saddle point solver

### DIFF
--- a/ir_std.h
+++ b/ir_std.h
@@ -22,6 +22,7 @@ extern "C" {
 Beg_struct(lua_cb_data)
   ir_int(fref, -1) // -1 == LUA_REFNIL
   ir_int(npnr, -9) // packed nprm,nret
+  ir_int(base_npnr, -9) // unaltered version
   ir_ptr(data)
 End_struct(lua_cb_data)
 

--- a/irep.c
+++ b/irep.c
@@ -154,11 +154,8 @@ int ir_nret(int npnr) { return npnr/1024 - 9; }
 
 // Read a Lua callback function.
 static int read_cbk(lua_State *L,char *lrep,void *bp,ir_element *ep) {
-  int i, ii, fref = LUA_NOREF, tv = lua_type(L,-1), npnr = ep->len;
+  int i, ii, fref = LUA_NOREF, tv = lua_type(L,-1), npnr = ep->len, base_npnr = ep->len;
   lua_cb_data *cb = (lua_cb_data *)bp;
-
-  // Save the original npnr, which may be overwritten below
-  base_npnr = npnr;
 
   if (tv!=LUA_TNUMBER && tv!=LUA_TTABLE && tv!=LUA_TFUNCTION)
     return Ir_error("Expected function, array, or number: %s", lrep);
@@ -212,6 +209,7 @@ static int read_cbk(lua_State *L,char *lrep,void *bp,ir_element *ep) {
     }
   }
   cb->npnr = npnr;
+  cb->base_npnr = base_npnr;
   Dbg_print("%s.npnr = %d (%d,%d)", lrep, npnr, ir_nprm(npnr),ir_nret(npnr));
   cb->fref = fref;
   Dbg_print("%s.fref = %d", lrep, fref);

--- a/irep.c
+++ b/irep.c
@@ -157,6 +157,9 @@ static int read_cbk(lua_State *L,char *lrep,void *bp,ir_element *ep) {
   int i, ii, fref = LUA_NOREF, tv = lua_type(L,-1), npnr = ep->len;
   lua_cb_data *cb = (lua_cb_data *)bp;
 
+  // Save the original npnr, which may be overwritten below
+  base_npnr = npnr;
+
   if (tv!=LUA_TNUMBER && tv!=LUA_TTABLE && tv!=LUA_TFUNCTION)
     return Ir_error("Expected function, array, or number: %s", lrep);
 


### PR DESCRIPTION
This is needed to get the radiation energy boundary conditions working.  The user needs to pass in a table of length ngroups.